### PR TITLE
fix(upload): resolve folder upload parentFolderId issue

### DIFF
--- a/src/app/api/upload/utils/presign-logic.ts
+++ b/src/app/api/upload/utils/presign-logic.ts
@@ -6,6 +6,7 @@
 
 import { S3Client, PutObjectCommand } from '@aws-sdk/client-s3';
 import { getSignedUrl } from '@aws-sdk/s3-request-presigner';
+import { generateS3Key } from '@/lib/s3-service';
 
 const s3Client = new S3Client({
   region: process.env.AWS_S3_REGION || 'eu-central-1',
@@ -25,7 +26,8 @@ interface PresignParams {
 }
 
 export async function generatePresignedUrl({ userId, fileName, fileType, fileSize }: PresignParams) {
-  const s3Key = `uploads/${userId}/${Date.now()}_${fileName}`;
+  // Use unified S3 key generation for consistent folder structure
+  const s3Key = generateS3Key(fileName, userId);
 
   const command = new PutObjectCommand({
     Bucket: BUCKET_NAME,

--- a/src/lib/s3-service.ts
+++ b/src/lib/s3-service.ts
@@ -120,7 +120,8 @@ export async function handleS3UploadCompletion(req: NextRequest) {
 }
 
 // Get public URL for an S3 object
-export function getS3PublicUrl(key: string): string {
-  if (!key) return '';
-  return `https://${S3_BUCKET}.s3.${process.env.AWS_S3_REGION}.amazonaws.com/${key}`;
-}
+// NOTE: This function is currently unused - using generateS3PublicUrl from shared-utils.ts instead
+// export function getS3PublicUrl(key: string): string {
+//   if (!key) return '';
+//   return `https://${S3_BUCKET}.s3.${process.env.AWS_S3_REGION}.amazonaws.com/${key}`;
+// }

--- a/src/lib/s3.ts
+++ b/src/lib/s3.ts
@@ -1,5 +1,6 @@
 import { S3Client, PutObjectCommand, PutObjectCommandInput } from '@aws-sdk/client-s3';
 // import { getSignedUrl } from '@aws-sdk/s3-request-presigner';
+import { generateS3Key } from './s3-service';
 
 // S3 Configuration
 const s3Config = {
@@ -32,6 +33,7 @@ export function isS3Configured(): boolean {
 }
 
 // Generate a safe file name with user ID in the path
+// NOTE: This function is deprecated - use generateS3Key from s3-service.ts instead
 function generateSafeFileName(originalName: string, userId: string = 'anonymous'): string {
   const timestamp = Date.now();
   const safeFileName = originalName.replace(/[^a-zA-Z0-9-_\.]/g, '_');
@@ -49,7 +51,8 @@ export async function uploadToS3(file: File, buffer?: Buffer, userId?: string): 
 
   const fileBuffer = buffer || Buffer.from(await file.arrayBuffer());
   const cleanFileName = file.name.split('/').pop() || file.name; // Remove any path from the file name
-  const fileName = generateSafeFileName(cleanFileName, userId);
+  // Use unified S3 key generation for consistent folder structure
+  const fileName = generateS3Key(cleanFileName, userId || 'anonymous');
 
   const uploadParams: PutObjectCommandInput = {
     Bucket: S3_BUCKET,


### PR DESCRIPTION
- Add parentFolderId support to finalize service interfaces and functions
- Update S3 processing pipeline to pass parentFolderId through finalization
- Update complete API to accept and process parentFolderId in memory records
- Fix memoryId extraction from API response (commitData.data.id vs commitData.memoryId)
- Add comprehensive debugging logs for folder upload flow
- Ensure folder uploads properly link memories to parent folders
- Add s3-files-export.json to .gitignore

Resolves issue where folder uploads created individual memories instead of proper folder structure with parentFolderId relationships.